### PR TITLE
Install sfdx-cli via Archive Download

### DIFF
--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -1,7 +1,6 @@
 FROM heroku/heroku:18
 
 ENV DEBIAN_FRONTEND=noninteractive
-ARG SALESFORCE_CLI_VERSION=latest
 RUN apt-get update
 RUN echo 'f6d5a254de2734ad9e7b9b02777d47a9a7454059e2d5690cf25c5ea57280f060  ./nodejs.deb' > node-file-lock.sha \
   && curl -s -o nodejs.deb https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_10.16.2-1nodesource1_amd64.deb \
@@ -10,7 +9,9 @@ RUN apt-get install --assume-yes \
   ./nodejs.deb \ 
   openjdk-11-jdk-headless=11.0.4+11-1ubuntu2~18.04.3 \
   jq \
-  && npm install --global sfdx-cli@${SALESFORCE_CLI_VERSION} \
+  && mkdir ~/.sfdx-cli \
+  && wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C ~/.sfdx-cli --strip-components 1 \
+  && ~/.sfdx-cli/install \
   && rm nodejs.deb node-file-lock.sha
 
 RUN apt-get autoremove --assume-yes \

--- a/dockerfiles/Dockerfile_slim
+++ b/dockerfiles/Dockerfile_slim
@@ -1,20 +1,21 @@
 FROM heroku/heroku:18
 
 ENV DEBIAN_FRONTEND=noninteractive
-ARG SALESFORCE_CLI_VERSION=latest
 RUN apt-get update
 RUN echo 'f6d5a254de2734ad9e7b9b02777d47a9a7454059e2d5690cf25c5ea57280f060  ./nodejs.deb' > node-file-lock.sha \
-    && curl -s -o nodejs.deb https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_10.16.2-1nodesource1_amd64.deb \
-    && shasum --check node-file-lock.sha
+  && curl -s -o nodejs.deb https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_10.16.2-1nodesource1_amd64.deb \
+  && shasum --check node-file-lock.sha
 RUN apt-get install --assume-yes \
-    ./nodejs.deb \ 
-    openjdk-11-jdk-headless=11.0.4+11-1ubuntu2~18.04.3 \
-    && npm install --global sfdx-cli@${SALESFORCE_CLI_VERSION} \
-    && rm nodejs.deb node-file-lock.sha
+  ./nodejs.deb \ 
+  openjdk-11-jdk-headless=11.0.4+11-1ubuntu2~18.04.3 \
+  && mkdir ~/.sfdx-cli \
+  && wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C ~/.sfdx-cli --strip-components 1 \
+  && ~/.sfdx-cli/install \
+  && rm nodejs.deb node-file-lock.sha
 
 RUN apt-get autoremove --assume-yes \
-    && apt-get clean --assume-yes \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get clean --assume-yes \
+  && rm -rf /var/lib/apt/lists/*
 
 ENV SFDX_CONTAINER_MODE true
 ENV DEBIAN_FRONTEND=dialog


### PR DESCRIPTION
### What does this PR do?
This PR will utilize the SFDX-CLI archives:
https://developer.salesforce.com/media/salesforce-cli/manifest.json

To install the CLI in the docker image instead of using npm or yarn. This approach should yield performance improvements when building the Docker image because using the archives is a faster way to install the cli.
**TIME:**

**yarn/npm**
 1m17.881s
**Archive** 
 0m9.144s


### What issues does this PR fix or reference?
@W-6807529@