### PR TITLE
Prevent image builds from using cached layers

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -59,11 +59,11 @@ if (checkTags.includes(DOCKER_IMAGE_VERSION)) {
 
 /* SLIM VERSION */
 const slim_dockerBuildExitCode = shell.exec(
-  `docker build --file ./dockerfiles/Dockerfile_slim --build-arg SALESFORCE_CLI_VERSION=${SALESFORCE_CLI_VERSION} --tag ${DOCKER_HUB_REPOSITORY}:${DOCKER_IMAGE_VERSION}-slim .`
+  `docker build --file ./dockerfiles/Dockerfile_slim --build-arg SALESFORCE_CLI_VERSION=${SALESFORCE_CLI_VERSION} --tag ${DOCKER_HUB_REPOSITORY}:${DOCKER_IMAGE_VERSION}-slim --no-cache .`
 );
 /* FULL VERSION */
 const full_dockerBuildExitCode = shell.exec(
-  `docker build --file ./dockerfiles/Dockerfile_full --build-arg SALESFORCE_CLI_VERSION=${SALESFORCE_CLI_VERSION} --tag ${DOCKER_HUB_REPOSITORY}:${DOCKER_IMAGE_VERSION}-full .`
+  `docker build --file ./dockerfiles/Dockerfile_full --build-arg SALESFORCE_CLI_VERSION=${SALESFORCE_CLI_VERSION} --tag ${DOCKER_HUB_REPOSITORY}:${DOCKER_IMAGE_VERSION}-full --no-cache .`
 );
 
 // Push to the Docker Hub Registry


### PR DESCRIPTION
### What does this PR do?
This PR will add the `--no-cache` flag to the Docker build steps in `publish.sh`. This will help ensure that the latest version of the CLI is downloaded to the published images.
### What issues does this PR fix or reference?
Should I make a WI for this?