### PR TITLE
Update openJdk headless verion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ variables:
         echo "The sfdx-cli installation could not be verified"
         exit 1
       fi
-      if [[ ((`echo $JAVA_VERSION | grep -c "openjdk 11.0.5"` > 0))]]
+      if [[ ((`echo $JAVA_VERSION | grep -c "openjdk 11.0.6"` > 0))]]
       then
         echo "Java installed -" $JAVA_VERSION 
       else

--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -7,7 +7,7 @@ RUN echo 'f6d5a254de2734ad9e7b9b02777d47a9a7454059e2d5690cf25c5ea57280f060  ./no
   && shasum --check node-file-lock.sha
 RUN apt-get install --assume-yes \
   ./nodejs.deb \ 
-  openjdk-11-jdk-headless=11.0.5+10-0ubuntu1.1~18.04 \
+  openjdk-11-jdk-headless=11.0.6+10-1ubuntu1~18.04.1 \
   jq \
   && mkdir ~/.sfdx-cli \
   && wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C ~/.sfdx-cli --strip-components 1 \

--- a/dockerfiles/Dockerfile_slim
+++ b/dockerfiles/Dockerfile_slim
@@ -7,7 +7,7 @@ RUN echo 'f6d5a254de2734ad9e7b9b02777d47a9a7454059e2d5690cf25c5ea57280f060  ./no
   && shasum --check node-file-lock.sha
 RUN apt-get install --assume-yes \
   ./nodejs.deb \ 
-  openjdk-11-jdk-headless=11.0.5+10-0ubuntu1.1~18.04 \
+  openjdk-11-jdk-headless=11.0.6+10-1ubuntu1~18.04.1 \
   && mkdir ~/.sfdx-cli \
   && wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C ~/.sfdx-cli --strip-components 1 \
   && ~/.sfdx-cli/install \


### PR DESCRIPTION
### What does this PR do?
Update OpenJDK 11 headless version to: 11.0.6+10-1ubuntu1~18.04.1

