### PR TITLE
Update Node LTS v12.18.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ variables:
         echo "The Java installation could not be verified"
         exit 1
       fi
-      if [[ ((`echo $NODE_VERSION | grep -c "v12.18.1"` > 0))]]
+      if [[ ((`echo $NODE_VERSION | grep -c "v12.18.2"` > 0))]]
       then
         echo "Node installed -" $NODE_VERSION 
       else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ variables:
         echo "The Java installation could not be verified"
         exit 1
       fi
-      if [[ ((`echo $NODE_VERSION | grep -c "v10.16.2"` > 0))]]
+      if [[ ((`echo $NODE_VERSION | grep -c "v12.18.1"` > 0))]]
       then
         echo "Node installed -" $NODE_VERSION 
       else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ _refs:
 
 variables:
   - &node-build-image
-    - image: circleci/node:10.14.2-stretch
+    - image: circleci/node:12.18.2-stretch
   - &run-docker-build-slim
     name: Build Docker Image slim
     command: |

--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -2,8 +2,8 @@ FROM heroku/heroku:18
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN echo 'f6d5a254de2734ad9e7b9b02777d47a9a7454059e2d5690cf25c5ea57280f060  ./nodejs.deb' > node-file-lock.sha \
-  && curl -s -o nodejs.deb https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_10.16.2-1nodesource1_amd64.deb \
+RUN echo 'a028cba3dbb87635c2907c116de248fa93c29dff5e3f68d0f027c05b0f5e15ae  ./nodejs.deb' > node-file-lock.sha \
+  && curl -s -o nodejs.deb https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/nodejs_12.18.1-deb-1nodesource1_amd64.deb \
   && shasum --check node-file-lock.sha
 RUN apt-get install --assume-yes \
   ./nodejs.deb \ 

--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -2,8 +2,8 @@ FROM heroku/heroku:18
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN echo 'a028cba3dbb87635c2907c116de248fa93c29dff5e3f68d0f027c05b0f5e15ae  ./nodejs.deb' > node-file-lock.sha \
-  && curl -s -o nodejs.deb https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/nodejs_12.18.1-deb-1nodesource1_amd64.deb \
+RUN echo 'b78fc542858b83a96d712d6a2f493ae87e1af55040bc55fb68671af191016d19  ./nodejs.deb' > node-file-lock.sha \
+  && curl -s -o nodejs.deb https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-arm64.tar.gz \
   && shasum --check node-file-lock.sha
 RUN apt-get install --assume-yes \
   ./nodejs.deb \ 

--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -2,22 +2,24 @@ FROM heroku/heroku:18
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN echo 'b78fc542858b83a96d712d6a2f493ae87e1af55040bc55fb68671af191016d19  ./nodejs.deb' > node-file-lock.sha \
-  && curl -s -o nodejs.deb https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-arm64.tar.gz \
+RUN echo '2d316e55994086e41761b0c657e0027e9d16d7160d3f8854cc9dc7615b99a526  ./nodejs.tar.gz' > node-file-lock.sha \
+  && curl -s -o nodejs.tar.gz https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-x64.tar.gz \
   && shasum --check node-file-lock.sha
+RUN mkdir /usr/local/lib/nodejs \
+  && tar xf nodejs.tar.gz -C /usr/local/lib/nodejs/ --strip-components 1 \
+  && rm nodejs.tar.gz node-file-lock.sha
 RUN apt-get install --assume-yes \
-  ./nodejs.deb \ 
   openjdk-11-jdk-headless=11.0.7+10-2ubuntu2~18.04 \
   jq \
   && mkdir ~/.sfdx-cli \
   && wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C ~/.sfdx-cli --strip-components 1 \
-  && ~/.sfdx-cli/install \
-  && rm nodejs.deb node-file-lock.sha
+  && ~/.sfdx-cli/install
 
 RUN apt-get autoremove --assume-yes \
   && apt-get clean --assume-yes \
   && rm -rf /var/lib/apt/lists/*
 
+ENV PATH=/usr/local/lib/nodejs/bin:$PATH
 ENV SFDX_CONTAINER_MODE true
 ENV DEBIAN_FRONTEND=dialog
 ENV SHELL /bin/bash

--- a/dockerfiles/Dockerfile_slim
+++ b/dockerfiles/Dockerfile_slim
@@ -2,8 +2,8 @@ FROM heroku/heroku:18
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN echo 'a028cba3dbb87635c2907c116de248fa93c29dff5e3f68d0f027c05b0f5e15ae  ./nodejs.deb' > node-file-lock.sha \
-  && curl -s -o nodejs.deb https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/nodejs_12.18.1-deb-1nodesource1_amd64.deb \
+RUN echo 'b78fc542858b83a96d712d6a2f493ae87e1af55040bc55fb68671af191016d19  ./nodejs.deb' > node-file-lock.sha \
+  && curl -s -o nodejs.deb https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-arm64.tar.gz  \
   && shasum --check node-file-lock.sha
 RUN apt-get install --assume-yes \
   ./nodejs.deb \ 

--- a/dockerfiles/Dockerfile_slim
+++ b/dockerfiles/Dockerfile_slim
@@ -2,8 +2,8 @@ FROM heroku/heroku:18
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN echo 'f6d5a254de2734ad9e7b9b02777d47a9a7454059e2d5690cf25c5ea57280f060  ./nodejs.deb' > node-file-lock.sha \
-  && curl -s -o nodejs.deb https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_10.16.2-1nodesource1_amd64.deb \
+RUN echo 'a028cba3dbb87635c2907c116de248fa93c29dff5e3f68d0f027c05b0f5e15ae  ./nodejs.deb' > node-file-lock.sha \
+  && curl -s -o nodejs.deb https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/nodejs_12.18.1-deb-1nodesource1_amd64.deb \
   && shasum --check node-file-lock.sha
 RUN apt-get install --assume-yes \
   ./nodejs.deb \ 

--- a/dockerfiles/Dockerfile_slim
+++ b/dockerfiles/Dockerfile_slim
@@ -2,21 +2,24 @@ FROM heroku/heroku:18
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN echo 'b78fc542858b83a96d712d6a2f493ae87e1af55040bc55fb68671af191016d19  ./nodejs.deb' > node-file-lock.sha \
-  && curl -s -o nodejs.deb https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-arm64.tar.gz  \
+RUN echo '2d316e55994086e41761b0c657e0027e9d16d7160d3f8854cc9dc7615b99a526  ./nodejs.tar.gz' > node-file-lock.sha \
+  && curl -s -o nodejs.tar.gz https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-x64.tar.gz \
   && shasum --check node-file-lock.sha
+RUN mkdir /usr/local/lib/nodejs \
+  && tar xf nodejs.tar.gz -C /usr/local/lib/nodejs/ --strip-components 1 \
+  && rm nodejs.tar.gz node-file-lock.sha
 RUN apt-get install --assume-yes \
-  ./nodejs.deb \ 
   openjdk-11-jdk-headless=11.0.7+10-2ubuntu2~18.04 \
   && mkdir ~/.sfdx-cli \
   && wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C ~/.sfdx-cli --strip-components 1 \
-  && ~/.sfdx-cli/install \
-  && rm nodejs.deb node-file-lock.sha
+  && ~/.sfdx-cli/install
+  
 
 RUN apt-get autoremove --assume-yes \
   && apt-get clean --assume-yes \
   && rm -rf /var/lib/apt/lists/*
 
+ENV PATH=/usr/local/lib/nodejs/bin:$PATH
 ENV SFDX_CONTAINER_MODE true
 ENV DEBIAN_FRONTEND=dialog
 ENV SHELL /bin/bash

--- a/docs/checksum.md
+++ b/docs/checksum.md
@@ -1,0 +1,13 @@
+## How Do I Create a New Hash To for CI Validation?
+
+### Steps:
+
+With NodeJs as an example.
+
+1. [Download](https://nodejs.org/dist/) the file you wish to validate to a locally
+   ex `curl -s -o nodejs.tar.gz https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-x64.tar.gz`
+
+1. Use [shasum](https://ss64.com/osx/shasum.html) to generate a hash for the file your just downloaded.
+   `shasum -a 256 ./nodejs.tar.gz`
+
+1. Replace reference to the hash and file name in the Dockerfile with the output of step 2. Make sure you update all references to the old version of node and the url in the `curl` command.


### PR DESCRIPTION
### What does this PR do?
This PR will update the version of node installed in the salesforcedx Docker image from `v.10.14.2` to `v12.18.2`.
We previously used [Nodesource](https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/) and installed from a `.deb` file but there has since been new deoendency, `python-minimal`, added that is causing installation issues.
Do get around that we will now get Node directly from [Nodejs.org](https://nodejs.org/dist/v12.18.2/) at a tar.gz, which has no dependency issues but does require a different approach to install it.

### What issues does this PR fix or reference?
@W-7201498@