### PR TITLE
Always install the latest version of jdk 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ variables:
         echo "The sfdx-cli installation could not be verified"
         exit 1
       fi
-      if [[ ((`echo $JAVA_VERSION | grep -c "openjdk 11.0.7"` > 0))]]
+      if [[ ((`echo $JAVA_VERSION | grep -c "openjdk"` > 0))]]
       then
         echo "Java installed -" $JAVA_VERSION 
       else

--- a/dockerfiles/Dockerfile_full
+++ b/dockerfiles/Dockerfile_full
@@ -9,7 +9,7 @@ RUN mkdir /usr/local/lib/nodejs \
   && tar xf nodejs.tar.gz -C /usr/local/lib/nodejs/ --strip-components 1 \
   && rm nodejs.tar.gz node-file-lock.sha
 RUN apt-get install --assume-yes \
-  openjdk-11-jdk-headless=11.0.7+10-2ubuntu2~18.04 \
+  openjdk-11-jdk-headless \
   jq \
   && mkdir ~/.sfdx-cli \
   && wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C ~/.sfdx-cli --strip-components 1 \

--- a/dockerfiles/Dockerfile_slim
+++ b/dockerfiles/Dockerfile_slim
@@ -9,7 +9,7 @@ RUN mkdir /usr/local/lib/nodejs \
   && tar xf nodejs.tar.gz -C /usr/local/lib/nodejs/ --strip-components 1 \
   && rm nodejs.tar.gz node-file-lock.sha
 RUN apt-get install --assume-yes \
-  openjdk-11-jdk-headless=11.0.7+10-2ubuntu2~18.04 \
+  openjdk-11-jdk-headless \
   && mkdir ~/.sfdx-cli \
   && wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C ~/.sfdx-cli --strip-components 1 \
   && ~/.sfdx-cli/install


### PR DESCRIPTION
### What does this PR do?
This PR will use `apt-get` to install the latest version of the `openjdk-11-jdk-headless` instead of specifying a version. The CI validation will also just verify that Java is installed and not look for a specific version.

### What issues does this PR fix or reference?
